### PR TITLE
[PoC] Nested reflected types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ htmlcov/
 __pycache__/
 
 docs/source/developer/autogen*
+/.eggs

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -809,6 +809,7 @@ class SetModel(StructModel):
         ]
         super(SetModel, self).__init__(dmm, fe_type, members)
 
+
 @register_default(types.SetIter)
 class SetIterModel(StructModel):
     def __init__(self, dmm, fe_type):

--- a/numba/jitclass/base.py
+++ b/numba/jitclass/base.py
@@ -439,6 +439,8 @@ def ctor_impl(context, builder, sig, args):
         builder,
         context.get_constant(types.uintp, alloc_size),
         imp_dtor(context, builder.module, inst_typ),
+        # jitclass does not have an ownerobj as meminfo will destroyed by Python-side __del__
+        dtor2=context.get_constant_null(types.pyobject)     # TODO: is there a better way to get (void*) NULL?
     )
     data_pointer = context.nrt.meminfo_data(builder, meminfo)
     data_pointer = builder.bitcast(data_pointer,

--- a/numba/runtime/_nrt_pythonmod.c
+++ b/numba/runtime/_nrt_pythonmod.c
@@ -95,14 +95,14 @@ meminfo_alloc(PyObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, "n", &size)) {
         return NULL;
     }
-    mi = NRT_MemInfo_alloc(size);
+    mi = NRT_MemInfo_alloc(size, NULL);
     return PyLong_FromVoidPtr(mi);
 }
 
 /*
  * Like meminfo_alloc but set memory to zero after allocation and before
  * deallocation.
- */
+
 static PyObject *
 meminfo_alloc_safe(PyObject *self, PyObject *args) {
     NRT_MemInfo *mi;
@@ -110,9 +110,10 @@ meminfo_alloc_safe(PyObject *self, PyObject *args) {
     if (!PyArg_ParseTuple(args, "n", &size)) {
         return NULL;
     }
-    mi = NRT_MemInfo_alloc_safe(size);
+    mi = NRT_MemInfo_alloc_safe(size, NULL);
     return PyLong_FromVoidPtr(mi);
 }
+*/
 
 static PyMethodDef ext_methods[] = {
 #define declmethod(func) { #func , ( PyCFunction )func , METH_VARARGS , NULL }
@@ -127,7 +128,6 @@ static PyMethodDef ext_methods[] = {
     declmethod_noargs(memsys_get_stats_mi_free),
     declmethod(meminfo_new),
     declmethod(meminfo_alloc),
-    declmethod(meminfo_alloc_safe),
     { NULL },
 #undef declmethod
 };
@@ -157,10 +157,8 @@ declmethod(adapt_ndarray_from_python);
 declmethod(adapt_ndarray_to_python);
 declmethod(adapt_buffer_from_python);
 declmethod(MemInfo_alloc);
-declmethod(MemInfo_alloc_safe);
 declmethod(MemInfo_alloc_aligned);
-declmethod(MemInfo_alloc_safe_aligned);
-declmethod(MemInfo_alloc_dtor_safe);
+declmethod(MemInfo_alloc_dtor);
 declmethod(MemInfo_call_dtor);
 declmethod(MemInfo_new_varsize);
 declmethod(MemInfo_new_varsize_dtor);
@@ -193,6 +191,12 @@ MOD_INIT(_nrt_python) {
     PyModule_AddObject(m, "_MemInfo", (PyObject *) (&MemInfoType));
 
     PyModule_AddObject(m, "c_helpers", build_c_helpers_dict());
+
+    #ifdef NRT_ALLOC_SAFE
+        PyModule_AddIntConstant(m, "NRT_ALLOC_SAFE", 1);
+    #else
+        PyModule_AddIntConstant(m, "NRT_ALLOC_SAFE", 0);
+    #endif
 
     return MOD_SUCCESS_VAL(m);
 }

--- a/numba/runtime/nrt.py
+++ b/numba/runtime/nrt.py
@@ -89,8 +89,10 @@ class _Runtime(object):
         See `NRT_MemInfo_alloc_safe()` in "nrt.h" for details.
         """
         self._init_guard()
-        if safe:
-            mi = _nrt.meminfo_alloc_safe(size)
+        if safe and not _nrt.NRT_ALLOC_SAFE:
+            raise DeprecationWarning(
+                "safe allocation is now controled by a compile-time switch in nrt.h, this was not set."
+            )
         else:
             mi = _nrt.meminfo_alloc(size)
         return MemInfo(mi)

--- a/setup.py
+++ b/setup.py
@@ -207,7 +207,7 @@ packages = find_packages("numba", "numba")
 
 build_requires = ['numpy']
 
-install_requires = ['llvmlite>=0.24.0dev0', 'numpy']
+install_requires = ['llvmlite>=0.24.0.dev0', 'numpy']
 if sys.version_info < (3, 4):
     install_requires.extend(['enum34', 'singledispatch'])
 if sys.version_info < (3, 3):


### PR DESCRIPTION
POC that does reflected types containing reflected types. Currently only list are known to work.
Test `test_linalg.TestLinalgCond.test_linalg_cond` fails as the error is swallowed (see below)

To support nested reflected types we must guarantee `pyhonapi.decref` is called on the owner of the reflected type instance and that any data stored via `pythonapi.object_set_private_data` is erased when
the `MemInfo` is destroyed (strictly speaking, this need not happen immediately but must be done before returning to Python).

Since there are usecases where Numba is used without the Python runtime the `MemInfo` destructors should be separated into a generic part that only depends on the Numba runtime, and a Python specific part. Depending on the context only the Numba runtime dependent part would be used.

The current implementation is based on three members of the (altered) `MemInfo` struct
- `dtor`: is a `NRT_dtor_function` that takes care of the Numba runtime specific clean-up, ie
   typically calling `nrt.decref` on nested memory-managed types. `dtor` must not use the Python runtime
- `ownerobj` is  a `void*` pointing to the owning Python object or `NULL` if there is no owner
- `dtor2` is a  `NRT_dtor_function` that takes care of the Python runtime specific clean-up. I'd hope
  this will not be type specific, ie always `decref(ownerobj); object_reset_private_data(ownerobj);` 
    
`NRT_MemInfo_call_dtor` will call both `dtor` and `dtor2`. Currently my idea is to have the implementation of `dtor2` in `runtime.context.NRTContext` which would allow to switch to
different implementations by changing the context.

In order not to grow `MemInfo` too much I moved safe allocation to a compile time switch in `nrt.h`. To make `MemInfo->dtor` available even for varsize `MemInfo`s I added a `flags` member that indicates if a `MemInfo` is varsized or not. 

**TODOS** and debatable implementation choices
1. When the (currently theoretical) ability of passing `MemInfo`s from one language runtime to another is not a requirement, a single `dtor` member should be enough. 
2. Currently larger parts of array (un)boxing are in `_nrt_python.c` and hence cannot use the `dtor2` impl from `runtime.context.NRTContext` and there is no way to implement a `dtor` to clean-up memory-managed dtypes. If memory-managed dtypes are desired this code had to be generated by some context.
3. Current GIL managment is pretty inefficient. Every `MemInfo` with an `ownerobj` acquires/releases the GIL on destruction separately. 
4. You have to be careful with error handling. For example, current (un)boxers tend to `nrt.decref` whatever is allocated on error. However, this might trigger a `dtor2` that will wipe-out the error. Need to think about a strategy. (`test_linalg.TestLinalgCond.test_linalg_cond` failing seems to be an incarnation of this. See bottom of `targets.boxing._python_list_to_native` for one way to handle this, but that would be needed everywhere a `nrt.decref` might follow an error. Not very practical ...)    
